### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -1,6 +1,8 @@
 # This is a basic workflow to help you get started with Actions
 
 name: CI
+permissions:
+  contents: read
 
 # Controls when the workflow will run
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/frankbel237/frankbel237/security/code-scanning/1](https://github.com/frankbel237/frankbel237/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code and runs echo commands (no write operations), the minimal permission required is `contents: read`. This block should be added at the top level of the workflow (after the `name:` and before `jobs:`), so it applies to all jobs unless overridden. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
